### PR TITLE
use preferred DOI resolver

### DIFF
--- a/R/doi_to_bib.R
+++ b/R/doi_to_bib.R
@@ -8,10 +8,7 @@
 
 doi_to_bib <- function(x = '10.1371/journal.pone.0008500',
                        cat_it = TRUE){
-  x <- gsub("http://dx.doi.org/", "", x, fixed = TRUE)
-  x <- gsub("https://dx.doi.org/", "", x, fixed = TRUE)
-  x <- gsub("www.dx.doi.org/", "", x, fixed = TRUE)
-  x <- gsub("dx.doi.org/", "", x, fixed = TRUE)
+  x <- gsub("https:?//(www\\.)?(dx\\.)?doi.org/", "", x,)
   out <- paste0('curl -LH "Accept: text/bibliography; style=bibtex" https://doi.org/',
                 x)
   out <- system(out, intern = TRUE)

--- a/R/doi_to_bib.R
+++ b/R/doi_to_bib.R
@@ -12,7 +12,7 @@ doi_to_bib <- function(x = '10.1371/journal.pone.0008500',
   x <- gsub("https://dx.doi.org/", "", x, fixed = TRUE)
   x <- gsub("www.dx.doi.org/", "", x, fixed = TRUE)
   x <- gsub("dx.doi.org/", "", x, fixed = TRUE)
-  out <- paste0('curl -LH "Accept: text/bibliography; style=bibtex" http://dx.doi.org/',
+  out <- paste0('curl -LH "Accept: text/bibliography; style=bibtex" https://doi.org/',
                 x)
   out <- system(out, intern = TRUE)
   if(cat_it){

--- a/README.html
+++ b/README.html
@@ -478,7 +478,7 @@ plot_data &lt;-<span class="st"> </span><span class="kw">data.frame</span>(resul
 #&gt; title={Cytochrome P450/ABC transporter inhibition simultaneously enhances ivermectin pharmacokinetics in the mammal host and pharmacodynamics in Anopheles gambiae         },
 #&gt;  volume={7},
 #&gt;  ISSN={2045-2322},
-#&gt;  url={http://dx.doi.org/10.1038/s41598-017-08906-x},
+#&gt;  url={https://doi.org/10.1038/s41598-017-08906-x},
 #&gt;  DOI={10.1038/s41598-017-08906-x},
 #&gt;  number={1},
 #&gt;  journal={Scientific Reports},

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ And you'll get the following output, ready to copy-paste into your bibliography 
     #> title={Cytochrome P450/ABC transporter inhibition simultaneously enhances ivermectin pharmacokinetics in the mammal host and pharmacodynamics in Anopheles gambiae         },
     #>  volume={7},
     #>  ISSN={2045-2322},
-    #>  url={http://dx.doi.org/10.1038/s41598-017-08906-x},
+    #>  url={https://doi.org/10.1038/s41598-017-08906-x},
     #>  DOI={10.1038/s41598-017-08906-x},
     #>  number={1},
     #>  journal={Scientific Reports},


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by updating static DOI links, as well as code that generates new ones, and reg-exes that parse them.

Cheers :-)